### PR TITLE
Use PyLong_CheckExact not PyInt_CheckExact

### DIFF
--- a/_cdifflib3.c
+++ b/_cdifflib3.c
@@ -95,7 +95,7 @@ _find_longest_match_worker(
                     int k = 1;
 
                     jint = PyList_GET_ITEM(oj, oji);
-                    assert(PyInt_CheckExact(jint));
+                    assert(PyLong_CheckExact(jint));
                     j = (int)PyLong_AsLong(jint);
 
                     if (j < blo)


### PR DESCRIPTION
As far as I can tell this symbol got renamed in python 3:

https://py3c.readthedocs.io/en/latest/reference.html#c.PyInt_CheckExact provides a compatibility shim, and
https://docs.python.org/3/c-api/long.html#c.PyLong_CheckExact is listed as existing but there's no mention of PyInt_CheckExact.

I've had a user report that they got a runtime failure because PyInt_CheckExact was undefined when using this library. I'm not sure what configuration they're running in, but this patch feels like a reasonable way to avoid that possibility. PyLong_CheckExact was supported since 3.0, and this entire file is behind a Python 3 ifdef, so it seems safe.